### PR TITLE
fix: internal links to other level

### DIFF
--- a/docs/Over_OSPO-NL.md
+++ b/docs/Over_OSPO-NL.md
@@ -20,5 +20,5 @@ Group](https://todogroup.org/). We willen daar vooral ook samenwerking mee hebbe
 daar beschikbaar zijn. MAAR ... Nederlandse invulling, vertalingen en specifieke samenwerkingen passen beter in een
 eigen 'NL chapter', een eigen Nederlands initiatief. Vandaar [OSPO-NL](https://ospo-nl.github.io/kennisbank/) :rocket:
 
-Voor meer informatie over onze [community](Community/) en werkwijze, check onze [CONTRIBUTING
-GUIDE](Community/CONTRIBUTING/) en [CODE OF CONDUCT](Community/CODE_OF_CONDUCT/).
+Voor meer informatie over onze [community](/Community/) en werkwijze, check onze [CONTRIBUTING
+GUIDE](/Community/CONTRIBUTING/) en [CODE OF CONDUCT](/Community/CODE_OF_CONDUCT/).

--- a/docs/Over_OSPO-NL.md
+++ b/docs/Over_OSPO-NL.md
@@ -20,5 +20,5 @@ Group](https://todogroup.org/). We willen daar vooral ook samenwerking mee hebbe
 daar beschikbaar zijn. MAAR ... Nederlandse invulling, vertalingen en specifieke samenwerkingen passen beter in een
 eigen 'NL chapter', een eigen Nederlands initiatief. Vandaar [OSPO-NL](https://ospo-nl.github.io/kennisbank/) :rocket:
 
-Voor meer informatie over onze [community](/Community/) en werkwijze, check onze [CONTRIBUTING
-GUIDE](/Community/CONTRIBUTING/) en [CODE OF CONDUCT](/Community/CODE_OF_CONDUCT/).
+Voor meer informatie over onze [community](../Community/) en werkwijze, check onze [CONTRIBUTING
+GUIDE](../Community/CONTRIBUTING/) en [CODE OF CONDUCT](../Community/CODE_OF_CONDUCT/).


### PR DESCRIPTION
Deze interne links werken niet ... vanuit 'over ons' naar 'Community/*'. Lokaal werkt het nu wel ... maar werkt het dan ook in de published GitHub Pages variant? Lokaal draait het namelijk op de root (`/`) maar de gepubliceerde documentatie draait op `/kennisbank` ...