### PR TITLE
docs: inrichten github organisatie

### DIFF
--- a/docs/Best practices/GitHub.md
+++ b/docs/Best practices/GitHub.md
@@ -1,4 +1,6 @@
-# Inrichten GitHub organisatie
+# GitHub
+
+Tips voor het gebruik van GitHub en het inrichten van de GitHub organisatie.
 
 ## .github repository
 

--- a/docs/Best practices/github/inrichten-github-organisatie.md
+++ b/docs/Best practices/github/inrichten-github-organisatie.md
@@ -1,0 +1,13 @@
+# Inrichten GitHub organisatie
+
+## .github repository
+
+De `.github` repositorynaam in je organisatie is gereserveerd voor organisatiebrede configuraties.
+Enkele functionaliteiten die beschikbaar zijn door bestanden toe te voegen aan deze repository:
+
+ - [Organization profile](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) om meer tekst en uitleg te geven bij je organisatie.
+ - [Default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#about-default-community-health-files) de standaard informatie zoals een CODE_OF_CONDUCT en CONTRIBUTING file die dan geldt voor alle repositories in de organisatie.
+ - [Issue en Pull Request templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) die actief zijn voor alle repositories in de organisatie.
+ - [Workflow templates](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization) als startpunt voor een nieuwe GitHub Actions workflow.
+
+Zie bijvoorbeeld de [.github repository van GitHub zelf](https://github.com/github/.github).


### PR DESCRIPTION
Initiële opzet voor inrichten GitHub organisatie.
In een aparte map omdat er mogelijk eenzelfde soort informatie komt voor GitLab
en andere software.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>
