### PR TITLE
link naar backlog

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -6,3 +6,4 @@ Hier vind je alle informatie over de OSPO-NL community. Check:
 - onze [Contributing Guide](./CONTRIBUTING.md)
 - onze [Code of Conduct](./CODE_OF_CONDUCT.md) (gedragscode)
 - waar je meer [ondersteuning](./SUPPORT.md) (support) kunt vinden
+- onze [backlog](https://github.com/orgs/ospo-nl/projects/1)


### PR DESCRIPTION
Een link naar onze backlog ... ontbreekt nog in de kennisbank! Hij staat wel genoemd in onze 'root' ([https://github.com/ospo-nl](https://github.com/ospo-nl)) maar verder niet.

Is alleen in de community pagina voldoende?